### PR TITLE
Add dist-gem5 support

### DIFF
--- a/marker.h
+++ b/marker.h
@@ -95,6 +95,13 @@ static __attribute__((optimize("O0"))) void m5_reset_stats(uint64_t x, uint64_t 
 	asm volatile (".inst 0xff400110;":: "r" (x0), "r" (x1));
 }
 
+static __attribute__((optimize("O0"))) void m5_dump_stats(uint64_t x, uint64_t y)
+{
+	register uint64_t x0 asm("x0") = x;
+	register uint64_t x1 asm("x1") = y;
+	asm volatile (".inst 0xff410110;":: "r" (x0), "r" (x1));
+}
+
 static __attribute__((optimize("O0"))) void m5_dumpreset_stats(uint64_t x, uint64_t y)
 {
 	register uint64_t x0 asm("x0") = x;

--- a/marker.h
+++ b/marker.h
@@ -137,6 +137,7 @@ void m5_work_end(uint64_t x, uint64_t y) {}
 #define GEM5_STAT     1
 #define GEM5_CHCK     2
 #define GEM5_EXIT     4
+#define GEM5_DIST     8
 #define GEM5_WORK     16
 
 inline int env2int(const char *name)
@@ -158,21 +159,28 @@ inline int env2int(const char *name)
 }
 
 #define MARKER_START(rank) \
-	if((rank==0)&&(_ARM_MARKER > 0)&&(_GEM5_MARKER > 0)) { \
-		if(_GEM5_MARKER & GEM5_CHCK) \
-			m5_checkpoint(_GEM5_CHCK_DELAY,_GEM5_CHCK_PERIOD); \
-		if(_GEM5_MARKER & GEM5_STAT) { \
-			if(_GEM5_STAT_DELAY||_GEM5_STAT_PERIOD) \
-				m5_dumpreset_stats(_GEM5_STAT_DELAY,_GEM5_STAT_PERIOD); \
-			else \
-				m5_reset_stats(0,0); \
-		} \
-	}
+	if((_ARM_MARKER > 0)&&(_GEM5_MARKER > 0)) { \
+                if((rank==0)||(_GEM5_MARKER & GEM5_DIST)) { \
+                        if(_GEM5_MARKER & GEM5_CHCK) \
+			        m5_checkpoint(_GEM5_CHCK_DELAY,_GEM5_CHCK_PERIOD); \
+		        if(_GEM5_MARKER & GEM5_STAT) { \
+                            if(_GEM5_STAT_DELAY||_GEM5_STAT_PERIOD) { \
+				        m5_dumpreset_stats(_GEM5_STAT_DELAY,_GEM5_STAT_PERIOD); \
+                            } else { \
+                                    m5_reset_stats(0,0); } \
+                        } \
+                } \
+         }
+
+
 #define MARKER_STOP(rank) \
-	if((rank==0)&&(_ARM_MARKER > 0)&&(_GEM5_MARKER > 0)) { \
-		if(_GEM5_MARKER & GEM5_STAT) m5_dumpreset_stats(0,0); \
-		if(_GEM5_MARKER & GEM5_EXIT) m5_exit(0); \
-		if(_GEM5_MARKER & GEM5_CHCK) m5_checkpoint(0,0); \
+	if((_ARM_MARKER > 0)&&(_GEM5_MARKER > 0)) { \
+                if((rank==0)||(_GEM5_MARKER & GEM5_DIST)) { \
+                    if(_GEM5_MARKER & GEM5_STAT) m5_dumpreset_stats(0,0); \
+                    if(_GEM5_MARKER & GEM5_EXIT) m5_exit(0); \
+                    if((_GEM5_MARKER & GEM5_CHCK)&&(!(_GEM5_MARKER & GEM5_EXIT))) \
+                        m5_checkpoint(0,0); \
+                } \
 	}
 #define MARKER_BEGIN(x, y) \
 	if(_GEM5_MARKER & GEM5_WORK) { \


### PR DESCRIPTION
When using dist-gem5, every (gem5) process needs to call m5_checkpoint/m5_reset_stats/m5_exit from MARKER_START/MARKER_END. Note that this assumes that we simulate a single MPI rank per node (i.e. per gem5).
